### PR TITLE
Add language support for local_pickup shipping method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
-= 2018.nn.nn - version 2.2.1 =
-
- * Localization - Add French translation, thanks to [Genesis Technologies](https://www.groupe-genesis.fr)
+= 2019.nn.nn - version 2.2.1-dev.1 =
+ * Tweak - Adjust label for local pickup shipping methods, props [spoyntersmith](https://github.com/spoyntersmith)
+ * Localization - Updated German translation, props [uok](https://github.com/uok)
+ * Localization - Add French translation, props [Genesis Technologies](https://www.groupe-genesis.fr)
 
 = 2018.11.09 - version 2.2.0 =
  * Misc - Add support for WP 5.0 and WC 3.5

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -19,7 +19,7 @@
  * @package   WC-Shipping-Estimate
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2015-2018, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
@@ -711,7 +711,7 @@ class Plugin {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $installed_version the currently installed version of the plugin
+	 * @param int $version the currently installed version of the plugin
 	 */
 	private function upgrade( $version ) {
 

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -166,6 +166,13 @@ class Plugin {
 		$days_from = apply_filters( 'wc_shipping_estimate_days_from', $days_from_setting );
 		$days_to   = apply_filters( 'wc_shipping_estimate_days_to', $days_to_setting );
 
+		// If shipping method is local_pickup set variable for label
+		if( substr( $method->id, 0, 12 ) === "local_pickup" ) {
+            $local_pickup = true;
+		} else {
+			$local_pickup = false;
+		};
+		
 		// Determine how we should format the estimate
 		if ( ! empty( $days_from_setting ) && ! empty( $days_to_setting ) ) {
 
@@ -213,12 +220,19 @@ class Plugin {
 		$days_from = apply_filters( 'wc_shipping_estimate_dates_from', date_i18n( 'F j', strtotime( $days_from_setting . 'days' ) ) );
 		$days_to   = apply_filters( 'wc_shipping_estimate_dates_to', date_i18n( 'F j', strtotime( $days_to_setting . 'days' ) ) );
 
+		// If shipping method is local_pickup set variable for label
+		if( substr( $method->id, 0, 12 ) === "local_pickup" ) {
+			$local_pickup = true;
+		} else {
+			$local_pickup = false;
+		};
+		
 		// Determine how we should format the estimate
 		if ( ! empty( $days_from_setting ) && ! empty( $days_to_setting ) ) {
 
 			// Sanity check: we can't show something like "Estimated delivery: January 5 to January 1" ;)
 			if ( $days_to_setting <= $days_from_setting ) {
-
+				
 				/* translators: %s (date) is latest shipping estimate */
 				$label .= sprintf( __( 'Estimated delivery by %s', 'woocommerce-shipping-estimate' ), $days_to );
 

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -137,9 +137,9 @@ class Plugin {
 
 		// Should we display days or dates to the customer?
 		if ( 'dates' === get_option( 'wc_shipping_estimate_format', 'days' ) ) {
-			$label = $this->generate_delivery_estimate_dates( $days_from_setting, $days_to_setting, $label );
+			$label = $this->generate_delivery_estimate_dates( $days_from_setting, $days_to_setting, $label, $method );
 		} else {
-			$label = $this->generate_delivery_estimate_days( $days_from_setting, $days_to_setting, $label );
+			$label = $this->generate_delivery_estimate_days( $days_from_setting, $days_to_setting, $label, $method );
 		}
 
 		// label complete
@@ -156,10 +156,11 @@ class Plugin {
 	 *
 	 * @param int $days_from_setting the minimum shipping estimate
 	 * @param int $days_to_setting the maximum shipping estimate
+	 * @param \WC_Shipping_Rate $method the shipping method
 	 * @param string $label the label we're in the process of updating
 	 * @return string $label the updated label with the delivery estimate
 	 */
-	private function generate_delivery_estimate_days( $days_from_setting, $days_to_setting, $label ) {
+	private function generate_delivery_estimate_days( $days_from_setting, $days_to_setting, $label, $method ) {
 
 		// Filter the "days" value in case you want to add a buffer or whatever ¯\_(ツ)_/¯
 		$days_from = apply_filters( 'wc_shipping_estimate_days_from', $days_from_setting );
@@ -202,10 +203,11 @@ class Plugin {
 	 *
 	 * @param int $days_from_setting the minimum shipping estimate
 	 * @param int $days_to_setting the maximum shipping estimate
+	 * @param \WC_Shipping_Rate $method the shipping method
 	 * @param string $label the label we're in the process of updating
 	 * @return string $label the updated label with the delivery dates
 	 */
-	private function generate_delivery_estimate_dates( $days_from_setting, $days_to_setting, $label ) {
+	private function generate_delivery_estimate_dates( $days_from_setting, $days_to_setting, $label, $method ) {
 
 		// Filter the "dates" value so it can be changed
 		$days_from = apply_filters( 'wc_shipping_estimate_dates_from', date_i18n( 'F j', strtotime( $days_from_setting . 'days' ) ) );

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -180,23 +180,40 @@ class Plugin {
 			if ( $days_to_setting <= $days_from_setting ) {
 
 				/* translators: %1$s (number) is maximum shipping estimate, %2$s is label (day(s)) */
-				$label .= sprintf( __( 'Delivery estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+				if ($local_pickup === true){
+					$label .= sprintf( __( 'Collection estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+				} else {
+					$label .= sprintf( __( 'Delivery estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+				}
 
 			} else {
 
 				/* translators: %1$s (number) is minimum shipping estimate, %2$s (number) is maximum shipping estimate, %$3s is label (day(s)) */
-				$label .= sprintf( __( 'Delivery estimate: %1$s - %2$s %3$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to, $this->get_estimate_label( $days_to ) );
+				if ($local_pickup === true){
+					$label .= sprintf( __( 'Collection estimate: %1$s - %2$s %3$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to, $this->get_estimate_label( $days_to ) );					
+				} else {
+					$label .= sprintf( __( 'Delivery estimate: %1$s - %2$s %3$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to, $this->get_estimate_label( $days_to ) );					
+				}
+
 			}
 
 		} elseif ( empty( $days_from_setting ) && ! empty( $days_to_setting ) ) {
 
 			/* translators: %1$s (number) is maximum shipping estimate, %2$s is label (day(s)) */
-			$label .= sprintf( __( 'Delivery estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+			if ($local_pickup === true){
+				$label .= sprintf( __( 'Collection estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+			} else {
+				$label .= sprintf( __( 'Delivery estimate: up to %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_to, $this->get_estimate_label( $days_to ) );
+			}
 
 		} elseif ( ! empty( $days_from_setting ) && empty( $days_to_setting ) ) {
 
 			/* translators: %1$s (number) is minimum shipping estimate, %2$s is label (day(s)) */
-			$label .= sprintf( __( 'Delivery estimate: at least %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_from, $this->get_estimate_label( $days_from ) );
+			if ($local_pickup === true){
+				$label .= sprintf( __( 'Collection estimate: at least %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_from, $this->get_estimate_label( $days_from ) );
+			} else {
+				$label .= sprintf( __( 'Delivery estimate: at least %1$s %2$s', 'woocommerce-shipping-estimate' ), $days_from, $this->get_estimate_label( $days_from ) );
+			}
 		}
 
 		return $label;
@@ -234,23 +251,39 @@ class Plugin {
 			if ( $days_to_setting <= $days_from_setting ) {
 				
 				/* translators: %s (date) is latest shipping estimate */
-				$label .= sprintf( __( 'Estimated delivery by %s', 'woocommerce-shipping-estimate' ), $days_to );
+				if ($local_pickup === true){
+					$label .= sprintf( __( 'Estimated collection by %s', 'woocommerce-shipping-estimate' ), $days_to );
+				} else {
+					$label .= sprintf( __( 'Estimated delivery by %s', 'woocommerce-shipping-estimate' ), $days_to );
+				}
 
 			} else {
 
 				/* translators: %1$s (date) is earliest shipping estimate, %2$s (date) is latest shipping estimate */
-				$label .= sprintf( __( 'Estimated delivery: %1$s - %2$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to );
+				if ($local_pickup === true){
+					$label .= sprintf( __( 'Estimated collection: %1$s - %2$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to );
+				} else {
+					$label .= sprintf( __( 'Estimated delivery: %1$s - %2$s', 'woocommerce-shipping-estimate' ), $days_from, $days_to );
+				}
 			}
 
 		} elseif ( empty( $days_from_setting ) && ! empty( $days_to_setting ) ) {
 
 			/* translators: %s (date) is latest shipping estimate */
-			$label .= sprintf( __( 'Estimated delivery by %s', 'woocommerce-shipping-estimate' ), $days_to );
+			if ($local_pickup === true){
+				$label .= sprintf( __( 'Estimated collection by %s', 'woocommerce-shipping-estimate' ), $days_to );
+			} else {
+				$label .= sprintf( __( 'Estimated delivery by %s', 'woocommerce-shipping-estimate' ), $days_to );
+			}
 
 		} elseif ( ! empty( $days_from_setting ) && empty( $days_to_setting ) ) {
 
 			/* translators: %s (date) is earliest shipping estimate */
-			$label .= sprintf( __( 'Delivery on or after %s', 'woocommerce-shipping-estimate' ), $days_from );
+			if ($local_pickup === true){
+				$label .= sprintf( __( 'Collection on or after %s', 'woocommerce-shipping-estimate' ), $days_from );
+			} else {				
+				$label .= sprintf( __( 'Delivery on or after %s', 'woocommerce-shipping-estimate' ), $days_from );
+			}
 		}
 
 		return $label;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -19,7 +19,7 @@
  * @package   WC-Shipping-Estimate
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2015-2018, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Requires at least: 4.4
 Tested up to: 4.9.8
 Requires PHP: 5.4
-Stable Tag: 2.2.0
+Stable Tag: 2.2.1-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -11,7 +11,7 @@
  * GitHub Plugin URI: Skyverge/woocommerce-shipping-estimate
  * GitHub Branch: master
  *
- * Copyright: (c) 2015-2018 SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2015-2019 SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -19,7 +19,7 @@
  * @package   WC-Shipping-Estimate
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2015-2018, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 2.6.14

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.2.0
+ * Version: 2.2.1-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * GitHub Plugin URI: Skyverge/woocommerce-shipping-estimate


### PR DESCRIPTION
> @spoyntersmith hey there, thanks for this contribution! This is a great idea.
> 
> It looks like this PR contains formatting changes for the entire plugin file, though, so we can't merge it as-is. Could you re-base / resubmit to isolate the proposed changes (without whitespace alterations)?
> 
> I'd prefer to pass the $method directly into the delivery dates helper instead of $local_pickup since we might need to check for other method types in the future, but I'm happy to make those changes after merge instead.

@bekarice following your recommendations I've re-written the code passing the $method to the generate functions. 

If in future there's a need to check for more methods, I was thinking of making $local_pickup a public function containing flat_rate or local_pickup etc. with a switch/case inside the generate_delivery_estimate_days()/generate_delivery_estimate_dates() functions. **Might** be cleaner.