### PR TITLE
[ch18879] WC 3.8 Compat

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2019.nn.nn - version 2.3.1-dev.1 =
+ * Misc - Add support for WooCommerce 3.8
+
 = 2019.08.15 - version 2.3.0 =
  * Tweak - Adjust label for local pickup shipping methods, props [spoyntersmith](https://github.com/spoyntersmith)
  * Localization - Updated German translation, props [uok](https://github.com/uok)

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.3.0';
+	const VERSION = '2.3.1-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.3.0
+ * Version: 2.3.1-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * GitHub Plugin URI: Skyverge/woocommerce-shipping-estimate
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  */
 
 defined( 'ABSPATH' ) or exit;

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -8,9 +8,6 @@
  * Version: 2.3.1-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
- * GitHub Plugin URI: Skyverge/woocommerce-shipping-estimate
- * GitHub Branch: master
- *
  * Copyright: (c) 2015-2019 SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0


### PR DESCRIPTION
# Summary

This release adds support for WC 3.8.

### Stories

- [CH 18879](https://app.clubhouse.io/skyverge/story/18879/wc-3-8-compatibility)

## Details

Shipping Estimates doesn't use the framework, so this is just a version bump & wc-tested-to bump.

## QA

- Activate WC Admin
- Activate Shipping Estimate
- Setup at least one shipping method
- Set a shipping estimate manually
- [x] Shipping Estimate Settings save correctly
- [x] Shipping estimate is displayed on frontend

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version