### PR TITLE
WC 3.9 Compatibility Release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2020.nn.nn - version 2.3.2-dev.1 =
+ * Misc - Add support for WooCommerce 3.9
+
 = 2019.11.11 - version 2.3.1 =
  * Misc - Add support for WooCommerce 3.8
 

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.3.1';
+	const VERSION = '2.3.2-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -17,7 +17,7 @@
  * needs please refer to http://skyverge.com/products/woocommerce-shipping-estimate/ for more information.
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,8 @@
 		}
 	],
 	"require" : {
+		"mnsami/composer-custom-directory-installer": "1.1.*",
 		"skyverge/wc-plugin-updater": "^1.1"
-	},
-	"require-dev": {
-		"mnsami/composer-custom-directory-installer": "1.1.*"
 	},
 	"config": {
 		"vendor-dir": "vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -1,44 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e2e01ab07100b08a58dfbfb687aadc5",
+    "content-hash": "c004181629ad0aba68dc01bef7284cd2",
     "packages": [
-        {
-            "name": "skyverge/wc-plugin-updater",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/skyverge/wc-plugin-updater.git",
-                "reference": "892fd8d95656c10f36dde0fdc62e465fabcd60da"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/892fd8d95656c10f36dde0fdc62e465fabcd60da",
-                "reference": "892fd8d95656c10f36dde0fdc62e465fabcd60da",
-                "shasum": ""
-            },
-            "type": "library",
-            "license": [
-                "GPL 3.0"
-            ],
-            "authors": [
-                {
-                    "name": "SkyVerge",
-                    "homepage": "https://skyverge.com"
-                }
-            ],
-            "description": "WooCommerce Plugin Updater",
-            "support": {
-                "source": "https://github.com/skyverge/wc-plugin-updater/tree/master",
-                "issues": "https://github.com/skyverge/wc-plugin-updater/issues"
-            },
-            "time": "2018-10-26T00:09:49+00:00"
-        }
-    ],
-    "packages-dev": [
         {
             "name": "mnsami/composer-custom-directory-installer",
             "version": "dev-master",
@@ -90,8 +57,40 @@
                 "composer-plugin"
             ],
             "time": "2017-08-14T19:50:19+00:00"
+        },
+        {
+            "name": "skyverge/wc-plugin-updater",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/skyverge/wc-plugin-updater.git",
+                "reference": "a01b359d9672bdbada7f71c945d159e386990383"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/a01b359d9672bdbada7f71c945d159e386990383",
+                "reference": "a01b359d9672bdbada7f71c945d159e386990383",
+                "shasum": ""
+            },
+            "type": "library",
+            "license": [
+                "GPL 3.0"
+            ],
+            "authors": [
+                {
+                    "name": "SkyVerge",
+                    "homepage": "https://skyverge.com"
+                }
+            ],
+            "description": "WooCommerce Plugin Updater",
+            "support": {
+                "source": "https://github.com/skyverge/wc-plugin-updater/tree/1.1.1",
+                "issues": "https://github.com/skyverge/wc-plugin-updater/issues"
+            },
+            "time": "2018-12-14T07:09:23+00:00"
         }
     ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": [],

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,7 +17,7 @@
  * needs please refer to http://skyverge.com/products/woocommerce-memberships-directory-shortcode/ for more information.
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Requires at least: 4.4
 Tested up to: 5.2.4
 Requires PHP: 5.6
-Stable Tag: 2.3.0
+Stable Tag: 2.3.2-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -16,7 +16,7 @@
  * @package   WC-Shipping-Estimate
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2015-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2015-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -8,7 +8,7 @@
  * Version: 2.3.2-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
- * Copyright: (c) 2015-2019 SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2015-2020 SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.3.1
+ * Version: 2.3.2-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * Copyright: (c) 2015-2019 SkyVerge, Inc. (info@skyverge.com)


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24732](https://app.clubhouse.io/skyverge/story/24732)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
