### PR TITLE
WooCommerce 4.0 compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
 = 2020.nn.nn - version 2.3.3-dev.1 =
+ * Misc - Add support for WooCommerce 4.0
 
 = 2020.01.08 - version 2.3.2 =
  * Misc - Add support for WooCommerce 3.9

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2020.nn.nn - version 2.3.3-dev.1 =
+
 = 2020.01.08 - version 2.3.2 =
  * Misc - Add support for WooCommerce 3.9
 

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.3.2';
+	const VERSION = '2.3.3-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Requires at least: 4.4
 Tested up to: 5.3.2
 Requires PHP: 5.6
-Stable Tag: 2.3.2
+Stable Tag: 2.3.3-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.3.2
+ * Version: 2.3.3-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * Copyright: (c) 2015-2020 SkyVerge, Inc. (info@skyverge.com)


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 4.0.

### Stories

- [CH 31043](https://app.clubhouse.io/skyverge/story/31043/woocommerce-4-0-compatibility)

## Details

There were no incompatibilities with WC 4.0.

## QA

- [x] Set up estimates for the current zones
- [x] Test estimates at checkout

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version