### PR TITLE
v2.3.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
 = 2020.nn.nn - version 2.3.5-dev.1 =
- * Fix - Addresses a potential PHP error while updating WooCommerce
+ * Fix - Address a potential PHP error while updating WooCommerce
  * Misc - Add support for WooCommerce 4.3
 
 = 2020.05.05 - version 2.3.4 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2020.nn.nn - version 2.3.5-dev.1 =
+ * Fix - Addresses a potential PHP error while updating WooCommerce
+ * Misc - Add support for WooCommerce 4.3
+
 = 2020.05.05 - version 2.3.4 =
  * Misc - Add support for WooCommerce 4.1
 

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.3.4';
+	const VERSION = '2.3.5-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mnsami/composer-custom-directory-installer.git",
-                "reference": "1ccaf2da421dd9f6bcec4631c38e69e67677125f"
+                "reference": "a4f6eec8a2d15be977561f22f4457e805d98108d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/1ccaf2da421dd9f6bcec4631c38e69e67677125f",
-                "reference": "1ccaf2da421dd9f6bcec4631c38e69e67677125f",
+                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/a4f6eec8a2d15be977561f22f4457e805d98108d",
+                "reference": "a4f6eec8a2d15be977561f22f4457e805d98108d",
                 "shasum": ""
             },
             "require": {
@@ -56,29 +56,29 @@
                 "composer-installer",
                 "composer-plugin"
             ],
-            "time": "2017-08-14T19:50:19+00:00"
+            "time": "2020-06-12T10:15:35+00:00"
         },
         {
             "name": "skyverge/wc-jilt-promotions",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "git@github.com:skyverge/wc-jilt-promotions.git",
-                "reference": "e9c8fdede446e33d6b4469d2c25d3d6817489b0b"
+                "url": "https://github.com/skyverge/wc-jilt-promotions.git",
+                "reference": "8900ebd4e1ab5106d9a4aaa95902682d660bb842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/skyverge/wc-jilt-promotions/zipball/e9c8fdede446e33d6b4469d2c25d3d6817489b0b",
-                "reference": "e9c8fdede446e33d6b4469d2c25d3d6817489b0b",
+                "url": "https://api.github.com/repos/skyverge/wc-jilt-promotions/zipball/8900ebd4e1ab5106d9a4aaa95902682d660bb842",
+                "reference": "8900ebd4e1ab5106d9a4aaa95902682d660bb842",
                 "shasum": ""
             },
             "type": "library",
             "description": "Callouts to promote Jilt in WooCommerce",
             "support": {
-                "source": "https://github.com/skyverge/wc-jilt-promotions/tree/master",
+                "source": "https://github.com/skyverge/wc-jilt-promotions/tree/1.0.2",
                 "issues": "https://github.com/skyverge/wc-jilt-promotions/issues"
             },
-            "time": "2020-05-04T23:03:09+00:00"
+            "time": "2020-07-09T19:01:46+00:00"
         },
         {
             "name": "skyverge/wc-plugin-updater",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Requires at least: 4.4
 Tested up to: 5.4.1
 Requires PHP: 5.6
-Stable Tag: 2.3.3
+Stable Tag: 2.3.5-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.3.4
+ * Version: 2.3.5-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * Copyright: (c) 2015-2020 SkyVerge, Inc. (info@skyverge.com)


### PR DESCRIPTION
Fixes #25 

Creates a new release to bump WC Jilt library to include a fix for a PHP error that may occur during WooCommerce core updates

### Story: [CH 58511](https://app.clubhouse.io/skyverge/story/58511)

## QA

- [ ] Make sure you have run `composer update`
- [x] Activate the plugin
- [x] Deactivate WooCommerce core