### PR TITLE
v2.4.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2020.nn.nn - version 2.4.0-dev.1 =
+
 = 2020.07.22 - version 2.3.5 =
  * Fix - Address a potential PHP error while updating WooCommerce
  * Misc - Add support for WooCommerce 4.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
 = 2020.nn.nn - version 2.4.0-dev.1 =
+ * Misc - Add compatibility for WooCommerce 4.7
+ * Misc - Require PHP 7.0 or newer
 
 = 2020.07.22 - version 2.3.5 =
  * Fix - Address a potential PHP error while updating WooCommerce

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.3.5';
+	const VERSION = '2.4.0-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,11 @@
     {
       "type": "vcs",
       "url": "https://github.com/skyverge/wc-plugin-updater"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/skyverge/wc-jilt-promotions"
     }
   ],
   "require": {
     "mnsami/composer-custom-directory-installer": "1.1.*",
-    "skyverge/wc-plugin-updater": "^1.1",
-    "skyverge/wc-jilt-promotions": "1.0.*"
+    "skyverge/wc-plugin-updater": "^1.1"
   },
   "config": {
     "vendor-dir": "vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c90c25d7a77b29e13458e7a0df8be699",
+    "content-hash": "c004181629ad0aba68dc01bef7284cd2",
     "packages": [
         {
             "name": "mnsami/composer-custom-directory-installer",
@@ -12,16 +12,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mnsami/composer-custom-directory-installer.git",
-                "reference": "a4f6eec8a2d15be977561f22f4457e805d98108d"
+                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/a4f6eec8a2d15be977561f22f4457e805d98108d",
-                "reference": "a4f6eec8a2d15be977561f22f4457e805d98108d",
+                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
+                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
+                "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3"
             },
             "type": "composer-plugin",
@@ -56,42 +56,20 @@
                 "composer-installer",
                 "composer-plugin"
             ],
-            "time": "2020-06-12T10:15:35+00:00"
-        },
-        {
-            "name": "skyverge/wc-jilt-promotions",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/skyverge/wc-jilt-promotions.git",
-                "reference": "8900ebd4e1ab5106d9a4aaa95902682d660bb842"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/skyverge/wc-jilt-promotions/zipball/8900ebd4e1ab5106d9a4aaa95902682d660bb842",
-                "reference": "8900ebd4e1ab5106d9a4aaa95902682d660bb842",
-                "shasum": ""
-            },
-            "type": "library",
-            "description": "Callouts to promote Jilt in WooCommerce",
-            "support": {
-                "source": "https://github.com/skyverge/wc-jilt-promotions/tree/1.0.2",
-                "issues": "https://github.com/skyverge/wc-jilt-promotions/issues"
-            },
-            "time": "2020-07-09T19:01:46+00:00"
+            "time": "2020-08-18T11:00:11+00:00"
         },
         {
             "name": "skyverge/wc-plugin-updater",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/skyverge/wc-plugin-updater.git",
-                "reference": "a01b359d9672bdbada7f71c945d159e386990383"
+                "reference": "81348332baf8cf52b3ffa4fe9031fbfa6bfa1123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/a01b359d9672bdbada7f71c945d159e386990383",
-                "reference": "a01b359d9672bdbada7f71c945d159e386990383",
+                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/81348332baf8cf52b3ffa4fe9031fbfa6bfa1123",
+                "reference": "81348332baf8cf52b3ffa4fe9031fbfa6bfa1123",
                 "shasum": ""
             },
             "type": "library",
@@ -106,10 +84,10 @@
             ],
             "description": "WooCommerce Plugin Updater",
             "support": {
-                "source": "https://github.com/skyverge/wc-plugin-updater/tree/1.1.1",
+                "source": "https://github.com/skyverge/wc-plugin-updater/tree/1.1.3",
                 "issues": "https://github.com/skyverge/wc-plugin-updater/issues"
             },
-            "time": "2018-12-14T07:09:23+00:00"
+            "time": "2020-11-19T02:12:41+00:00"
         }
     ],
     "packages-dev": [],

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Requires at least: 4.4
 Tested up to: 5.4.2
 Requires PHP: 5.6
-Stable Tag: 2.3.5
+Stable Tag: 2.4.0-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: skyverge, beka.rice
 Tags: woocommerce, shipping, shipping time, shipping estimate, woocommerce shipping
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Shipping+Estimates
-Requires at least: 4.4
+Requires at least: 5.2
 Tested up to: 5.4.2
-Requires PHP: 5.6
+Requires PHP: 7.0
 Stable Tag: 2.4.0-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.3.5
+ * Version: 2.4.0-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * Copyright: (c) 2015-2020 SkyVerge, Inc. (info@skyverge.com)

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -19,7 +19,7 @@
  * @copyright Copyright (c) 2015-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
- * WC requires at least: 3.0.9
+ * WC requires at least: 3.5
  * WC tested up to: 4.3.1
  */
 
@@ -34,13 +34,13 @@ class WC_Shipping_Estimate_Loader {
 
 
 	/** minimum PHP version required by this plugin */
-	const MINIMUM_PHP_VERSION = '5.6.0';
+	const MINIMUM_PHP_VERSION = '7.0';
 
 	/** minimum WordPress version required by this plugin */
-	const MINIMUM_WP_VERSION = '4.4';
+	const MINIMUM_WP_VERSION = '5.2';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '3.0.9';
+	const MINIMUM_WC_VERSION = '3.5';
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Shipping Estimate';
@@ -68,8 +68,6 @@ class WC_Shipping_Estimate_Loader {
 
 		// if the environment check passes, initialize the plugin
 		if ( $this->is_environment_compatible() ) {
-
-			require_once( 'vendor/skyverge/wc-jilt-promotions/load.php' );
 
 			add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
 		}


### PR DESCRIPTION
# Summary

This is the v2.4.0 main branch which will remove the Jilt Promotions package and bump WP, WC, and PHP versions.

### Stories

- [x] [CH 69121](https://app.clubhouse.io/skyverge/story/69121/remove-the-jilt-promotions-package-from-shipping-estimates) (#30)

### Final story

[CH 69121](https://app.clubhouse.io/skyverge/story/69121/remove-the-jilt-promotions-package-from-shipping-estimates)

## Before merge

- [x] I have confirmed the final story is merged