### PR TITLE
Release: 2.4.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Shipping Estimate Changelog ***
 
+= 2021.nn.nn - version 2.4.1-dev.1 =
+ * Fix - Fixes an issue with the plugin updater that could have prompted PHP errors
+
 = 2020.12.10 - version 2.4.0 =
  * Misc - Add compatibility for WooCommerce 4.7
  * Misc - Require PHP 7.0 or newer

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) or exit;
 class Plugin {
 
 
-	const VERSION = '2.4.0';
+	const VERSION = '2.4.1-dev.1';
 
 	/** @var Plugin single instance of this plugin */
 	protected static $instance;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "mnsami/composer-custom-directory-installer": "1.1.*",
+    "mnsami/composer-custom-directory-installer": "2.0.*",
     "skyverge/wc-plugin-updater": "^1.1"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c004181629ad0aba68dc01bef7284cd2",
+    "content-hash": "956773b66232695809913e3295f965a8",
     "packages": [
         {
             "name": "mnsami/composer-custom-directory-installer",
@@ -12,18 +12,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mnsami/composer-custom-directory-installer.git",
-                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9"
+                "reference": "f8bcf249ec4bafa12cc4f1b405f7754bae0574b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
-                "reference": "85f66323978d0b1cb0e6acc7f69b3e7b912f82d9",
+                "url": "https://api.github.com/repos/mnsami/composer-custom-directory-installer/zipball/f8bcf249ec4bafa12cc4f1b405f7754bae0574b1",
+                "reference": "f8bcf249ec4bafa12cc4f1b405f7754bae0574b1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3"
             },
+            "default-branch": true,
             "type": "composer-plugin",
             "extra": {
                 "class": [
@@ -32,7 +33,7 @@
                     "Composer\\CustomDirectoryInstaller\\PluginPlugin"
                 ],
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -56,20 +57,30 @@
                 "composer-installer",
                 "composer-plugin"
             ],
-            "time": "2020-08-18T11:00:11+00:00"
+            "support": {
+                "issues": "https://github.com/mnsami/composer-custom-directory-installer/issues",
+                "source": "https://github.com/mnsami/composer-custom-directory-installer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnsami",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-22T07:53:44+00:00"
         },
         {
             "name": "skyverge/wc-plugin-updater",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/skyverge/wc-plugin-updater.git",
-                "reference": "81348332baf8cf52b3ffa4fe9031fbfa6bfa1123"
+                "reference": "efdcdf0078de3dc9047ce0a3956c152e13870888"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/81348332baf8cf52b3ffa4fe9031fbfa6bfa1123",
-                "reference": "81348332baf8cf52b3ffa4fe9031fbfa6bfa1123",
+                "url": "https://api.github.com/repos/skyverge/wc-plugin-updater/zipball/efdcdf0078de3dc9047ce0a3956c152e13870888",
+                "reference": "efdcdf0078de3dc9047ce0a3956c152e13870888",
                 "shasum": ""
             },
             "type": "library",
@@ -84,10 +95,10 @@
             ],
             "description": "WooCommerce Plugin Updater",
             "support": {
-                "source": "https://github.com/skyverge/wc-plugin-updater/tree/1.1.3",
+                "source": "https://github.com/skyverge/wc-plugin-updater/tree/1.1.4",
                 "issues": "https://github.com/skyverge/wc-plugin-updater/issues"
             },
-            "time": "2020-11-19T02:12:41+00:00"
+            "time": "2021-06-29T13:27:35+00:00"
         }
     ],
     "packages-dev": [],
@@ -98,5 +109,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/woocommerce-shipping-estimate.php
+++ b/woocommerce-shipping-estimate.php
@@ -5,7 +5,7 @@
  * Description: Displays a shipping estimate for each method on the cart / checkout page
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.0
+ * Version: 2.4.1-dev.1
  * Text Domain: woocommerce-shipping-estimate
  *
  * Copyright: (c) 2015-2020 SkyVerge, Inc. (info@skyverge.com)


### PR DESCRIPTION
## Summary

Updates the SV Updater to 1.1.4 to address a bug fixed in that version: https://github.com/skyverge/wc-plugin-updater/releases/tag/1.1.4

Had to bump the `mnsami/composer-custom-directory-installer` for Composer 2 compatibility. After updating composer this package correctly installed the updater to the expected path.

Since https://github.com/skyverge/wc-plugin-updater/releases/tag/1.1.4 has been reviewed & released, and this PR merely updates that I may release this update straight.