### PR TITLE
Improve i18n for table headers in the plugin settings

### DIFF
--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -328,8 +328,8 @@ class Plugin {
 					<thead>
 						<tr style="background: #e9e9e9;">
 							<th colspan="4" style="text-align: center; border: 1px solid #e1e1e1;">
-								<?php echo sprintf( '<a href="%1$s">%2$s</a>', esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . $zone->get_id() ) ), $zone->get_zone_name() ); ?>
-								<?php esc_html_e( 'Methods', 'woocommerce-shipping-estimate' ); ?>
+							<?php /* translators: 1. URL, 2. zone name */ ?>
+								<?php echo sprintf( __( 'Shipping Methods for <a href="%1$s">%2$s</a>', 'woocommerce-shipping-estimate' ), esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . $zone->get_id() ) ), $zone->get_zone_name() ); ?>
 							</th>
 						</tr>
 						<tr>
@@ -367,9 +367,9 @@ class Plugin {
 					<thead>
 						<tr style="background: #e9e9e9;">
 							<th colspan="4" style="text-align: center; border: 1px solid #e1e1e1;">
-								<?php $zone_name = __( 'Rest of the World', 'woocommerce-shipping-estimate' ); ?>
-								<?php echo sprintf( '<a href="%1$s">%2$s</a>', esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=0' ) ), $zone_name ); ?>
-								<?php esc_html_e( 'Methods', 'woocommerce-shipping-estimate' ); ?>
+								<?php $zone_name = __( 'Rest of the world', 'woocommerce-shipping-estimate' ); ?>
+								<?php /* translators: 1. URL, 2. zone name */ ?>
+								<?php echo sprintf( __( 'Shipping Methods for <a href="%1$s">%2$s</a>', 'woocommerce-shipping-estimate' ), esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=0' ) ), $zone_name ); ?>
 							</th>
 						</tr>
 						<tr>

--- a/class-wc-shipping-estimate.php
+++ b/class-wc-shipping-estimate.php
@@ -328,7 +328,7 @@ class Plugin {
 					<thead>
 						<tr style="background: #e9e9e9;">
 							<th colspan="4" style="text-align: center; border: 1px solid #e1e1e1;">
-							<?php /* translators: 1. URL, 2. zone name */ ?>
+								<?php /* translators: 1. URL, 2. zone name */ ?>
 								<?php echo sprintf( __( 'Shipping Methods for <a href="%1$s">%2$s</a>', 'woocommerce-shipping-estimate' ), esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . $zone->get_id() ) ), $zone->get_zone_name() ); ?>
 							</th>
 						</tr>


### PR DESCRIPTION
I have translated the plugin into Spanish and I realized that there is a small issue with the translation of the table headers in the plugin settings. Currently, the word 'Methods' is forced to be displayed at the end of the sentence, but in some languages, like Spanish, this doesn't make sense, and need to be moved to the start of the sentence:

![image](https://user-images.githubusercontent.com/38109855/179579452-2f8af037-6db6-4fbb-9f8b-0d6cb6ec0de0.png)

This PR fix that: I have improved these headers, allowing the translator to move all the sentences parts if the language requires this. I also applied some small rewording, adding 'Shipping' word to make clear that the list shows shipping methods.

This is how the table headers looks in Spanish:

![image](https://user-images.githubusercontent.com/38109855/179580211-98159b68-decb-4cd3-a924-0a2114ac4296.png)